### PR TITLE
Updated PHP & MySQL versions

### DIFF
--- a/docs/guide/installation/problems.md
+++ b/docs/guide/installation/problems.md
@@ -38,8 +38,8 @@ RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}] # php-fpm support
 
 In order to run LUYA with deployer nicely on a production server, the following components should be installed (we use the most common components Apache2 and MySQL, of course you can run LUYA with other database components and webservers like nginx):
 
-+ PHP 7.4 (or higher) (PHP 7.0 and PHP 5.6 should work but it's not tested anymore)
-+ MySQL 5.5 (or higher)
++ PHP 8.0 (PHP 8.1 or higher recommended)
++ MySQL 5.5 (MySQL 8.0 or higher recommended)
 + PHP extensions: curl, fileinfo, mbstring, icu, phar, zip
 + Apache modules: mod_rewrite
 + Git (for deployer)


### PR DESCRIPTION
### What are you changing/introducing

- Updated PHP minimum version to 8.0 because of PHP 7.4 drop in https://github.com/luyadev/luya-module-admin/commit/f14e3b6dbb3f565b596f027b799b89b3e3864372 and https://github.com/luyadev/luya-module-cms/commit/a5676f127c68b63230e886a587264e1397ca9a2f
- Recommended *PHP 8.1 or higher* because PHP 8.0 has recently gone EOL, see https://endoflife.date/php
- Recommended *MySQL 8.0 or higher* because MySQL 5.5 is EOL for longer time, see https://endoflife.date/mysql